### PR TITLE
fix(quit button): quit menu item wasn't working on linux

### DIFF
--- a/app/conf/menu.js
+++ b/app/conf/menu.js
@@ -19,11 +19,7 @@ const main_menu = [{
       }
     },
     {
-      label: 'Quit',
-      accelerator: process.platform === 'darwin' ? SHORCUT_QUIT_IOS : SHORCUT_QUIT_WN,
-      click() {
-        app.quit();
-      }
+      role: 'quit'
     }
   ]
 }]


### PR DESCRIPTION
Can simplify the quit menu item by using role: 'quit' to be platform
agnostic.